### PR TITLE
Implement normalizePlan

### DIFF
--- a/src/lib/FlameExplain.test.ts
+++ b/src/lib/FlameExplain.test.ts
@@ -8,6 +8,7 @@ import {
   rowsXHuman,
   rowsXFraction,
 } from './FlameExplain';
+
 import NestedLoop from './example_plans/NestedLoop';
 import RewriteTwoQueries from './example_plans/RewriteTwoQueries';
 import OneInitFilter from './example_plans/OneInitFilter';

--- a/src/ui/Util.tsx
+++ b/src/ui/Util.tsx
@@ -18,3 +18,11 @@ export function setCancelable<T>(set: SetFn<T>): [SetFn<T>, CancelFn] {
 
 type SetFn<T> = (v: T) => void;
 type CancelFn = () => void;
+
+// normalizePlan deals with JSON plans produced by psql which have various
+// text decoration elements that need to be removed, see GH issue for more
+// details: https://github.com/felixge/flame-explain/issues/7
+export function normalizePlan(plan: string): string {
+  let cropped = plan.slice(plan.indexOf('['), plan.lastIndexOf(']') + 1);
+  return cropped.replace(/\+/g, '');
+}

--- a/src/ui/Visualizer.test.ts
+++ b/src/ui/Visualizer.test.ts
@@ -1,0 +1,28 @@
+import {normalizePlan} from './Util';
+
+describe('normalizePlan', () => {
+  test('remove header, footer and trailing plus symbol from psql plan', () => {
+    expect(
+      normalizePlan(
+        '$ psql psql (11.6)Type"help"for help.postgres=# EXPLAIN(ANALYZE,FORMAT JSON,VERBOSE,BUFFERS)SELECT1;QUERY PLAN-------------------------------------[+{+"Plan":{+"Node Type": "Result",+"Parallel Aware": false,+"Startup Cost": 0.00,+"Total Cost": 0.01,+"Plan Rows": 1,+"Plan Width":4,+"Actual Startup Time": 0.004,+"Actual Total Time": 0.005,+"Actual Rows": 1,+"Actual Loops": 1,+"Output": ["1"],+"Shared Hit Blocks": 0,+"Shared Read Blocks": 0,+"Shared Dirtied Blocks": 0,+"Shared Written Blocks": 0,+"Local Hit Blocks": 0,+"Local Read Blocks": 0,+"Local Dirtied Blocks": 0,+"Local Written Blocks": 0,+"Temp Read Blocks": 0,+"Temp Written Blocks": 0+},+"Planning Time": 0.168,+"Triggers":[+],+"Execution Time": 0.082+}+](1 row)'
+      )
+    ).toEqual(
+      '[{"Plan":{"Node Type": "Result","Parallel Aware": false,"Startup Cost": 0.00,"Total Cost": 0.01,"Plan Rows": 1,"Plan Width":4,"Actual Startup Time": 0.004,"Actual Total Time": 0.005,"Actual Rows": 1,"Actual Loops": 1,"Output": ["1"],"Shared Hit Blocks": 0,"Shared Read Blocks": 0,"Shared Dirtied Blocks": 0,"Shared Written Blocks": 0,"Local Hit Blocks": 0,"Local Read Blocks": 0,"Local Dirtied Blocks": 0,"Local Written Blocks": 0,"Temp Read Blocks": 0,"Temp Written Blocks": 0},"Planning Time": 0.168,"Triggers":[],"Execution Time": 0.082}]'
+    );
+  });
+  test('incomplete psql plan', () => {
+    expect(
+      normalizePlan(
+        '[+{+"Plan":{+"Node Type": "Result",+"Parallel Aware": false,+"Startup Cost": 0.00,+"Total Cost": 0.01,+"Plan Rows": 1,+"Plan Width":4,+"Actual Startup Time": 0.004,+"Actual Total Time": 0.005,+"Actual Rows": 1,+"Actual Loops": 1,+"Output": ["1"],+"Shared Hit Blocks":'
+      )
+    ).toEqual(
+      '[{"Plan":{"Node Type": "Result","Parallel Aware": false,"Startup Cost": 0.00,"Total Cost": 0.01,"Plan Rows": 1,"Plan Width":4,"Actual Startup Time": 0.004,"Actual Total Time": 0.005,"Actual Rows": 1,"Actual Loops": 1,"Output": ["1"]'
+    );
+  });
+  test('remove all plus symbols', () => {
+    expect(normalizePlan('+++')).toEqual('');
+  });
+  test('crop symbols between the first opening bracket [ and the last closing bracket ]', () => {
+    expect(normalizePlan('x[[x]]]x')).toEqual('[[x]]]');
+  });
+});

--- a/src/ui/Visualizer.tsx
+++ b/src/ui/Visualizer.tsx
@@ -14,6 +14,7 @@ import {useLocalStorage} from './LocalStorage';
 import {useGist, GistNotice} from './Gist';
 import {useKeyboardShortcuts} from './KeyboardShortcuts';
 import Highlight from './Highlight';
+import {normalizePlan} from './Util';
 
 export type VisualizerState = {
   input: InputState;
@@ -56,7 +57,7 @@ export default function Visualizer() {
     setState(state => ({
       ...state,
       ...{
-        input: newInput,
+        input: {plan: normalizePlan(newInput.plan), sql: newInput.sql},
         collapsed: {},
         selectedNode: undefined,
       },


### PR DESCRIPTION
This commit implements normalizePlan which allows users to paste the raw output of psql into FlameExplain without having to first manually normalize it (i.e. remove + characters and anything else that isn't JSON).

Fixes #7