### PR TITLE
Center footer content

### DIFF
--- a/src/ui/index.sass
+++ b/src/ui/index.sass
@@ -38,13 +38,7 @@ table.tree-table
   flex-direction: column;
 
 .content-wrapper
-  flex: 1;
-
-// Center footer content
-.footer
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  flex: 1; 
 
 .navbar
   // Align navbar with body content (looks better to me)

--- a/src/ui/index.sass
+++ b/src/ui/index.sass
@@ -3,6 +3,7 @@
 // Update Bulma's global variables
 $family-sans-serif: "Nunito", sans-serif;
 $panel-heading-padding: 0.25em 0.5em;
+$footer-padding: 3rem;
 
 // Import the rest of Bulma
 @import "bulma";
@@ -37,7 +38,13 @@ table.tree-table
   flex-direction: column;
 
 .content-wrapper
-  flex: 1; 
+  flex: 1;
+
+// Center footer content
+.footer
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
 .navbar
   // Align navbar with body content (looks better to me)


### PR DESCRIPTION
This PR centres the footer content.
Beforehand it wasn't centred vertically because of Bulma's default footer styling (i.e. `$footer-padding: 3rem 1.5rem 6rem`).
It is overridden in this PR (i.e. `$footer-padding: 3rem`) and fixes the problem. 
How do you like the solution? 